### PR TITLE
Fix golangci-lint errors.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,8 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        # Note: this is @v3.2.0.
+        uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:
           version: v1.43
           args: --timeout=3m

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: golangci-lint
-        # TODO: fix golangci-lint errors and warnings, and remove continue-on-error
-        continue-on-error: true
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.43

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,14 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.43
       -
@@ -39,12 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.16.x
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: goreleaser deprecation
       run: curl -sfL https://git.io/goreleaser | VERSION=v1.2.5 sh -s -- check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:
           version: v1.43
-          args: --timeout=3m
+          args: --timeout=5m
       -
         name: Tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.43
+          args: --timeout=3m
       -
         name: Tests
         run: |

--- a/api/aws.go
+++ b/api/aws.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	awsSession *session.Session
-	awsCreds   *credentials.Credentials
 )
 
 func initAws(ctx context.Context) {
@@ -46,7 +45,6 @@ func initAws(ctx context.Context) {
 		log.Error(ctx, "AWS not initialized", "error", err.Error())
 		return
 	}
-	awsCreds = creds
 	cfg := aws.NewConfig().WithRegion(config.AWS.Region).WithCredentials(creds)
 	if config.AWS.S3Endpoint != "" {
 		cfg = cfg.WithEndpoint(config.AWS.S3Endpoint)

--- a/api/backup_test.go
+++ b/api/backup_test.go
@@ -26,7 +26,7 @@ func TestBackupController_Status(t *testing.T) {
 	}
 	createList(t, t.Name(), elems)
 	createList(t, t.Name()+"-2", elems)
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, _ := ioutil.TempDir("", t.Name())
 	fileName := filepath.Join(dir, t.Name()+".bin")
 	payload := client.MultiListBackup{
 		Destination: &client.BackupDestination{
@@ -107,7 +107,7 @@ func TestBackupController_Delete(t *testing.T) {
 	}
 	createList(t, t.Name(), elems)
 	createList(t, t.Name()+"-2", elems)
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, _ := ioutil.TempDir("", t.Name())
 	fileName := filepath.Join(dir, t.Name()+".bin")
 	payload := client.MultiListBackup{
 		Destination: &client.BackupDestination{

--- a/api/health.go
+++ b/api/health.go
@@ -63,24 +63,21 @@ func (c *HealthController) Health(ctx *app.HealthHealthContext) error {
 func (c *HealthController) memoryReader() {
 	ctx := c.Context
 	ticker := time.Tick(time.Minute)
-	for {
-		select {
-		case <-ticker:
-			var mem runtime.MemStats
-			runtime.ReadMemStats(&mem)
-			j, err := json.MarshalIndent(mem, "", "\t")
-			if err != nil {
-				log.Error(ctx, "unable to marshal memstats", "error", err.Error())
-			}
-			var m map[string]interface{}
-			err = json.Unmarshal(j, &m)
-			if err != nil {
-				log.Error(ctx, "unable to unmarshal memstats", "error", err.Error())
-			}
-			c.memoryMuStats.Lock()
-			c.memoryStats = m
-			c.memoryMuStats.Unlock()
+	for range ticker {
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+		j, err := json.MarshalIndent(mem, "", "\t")
+		if err != nil {
+			log.Error(ctx, "unable to marshal memstats", "error", err.Error())
 		}
+		var m map[string]interface{}
+		err = json.Unmarshal(j, &m)
+		if err != nil {
+			log.Error(ctx, "unable to unmarshal memstats", "error", err.Error())
+		}
+		c.memoryMuStats.Lock()
+		c.memoryStats = m
+		c.memoryMuStats.Unlock()
 	}
 }
 

--- a/api/lists.go
+++ b/api/lists.go
@@ -130,7 +130,7 @@ func (c *ListsController) GetPercentile(ctx *app.GetPercentileListsContext) erro
 	if !ok {
 		return ctx.NotFound(goa.ErrNotFound("not_found", "list_id", ctx.ListID))
 	}
-	percentile := float64(50.0)
+	var percentile float64
 	if fromTop, err2 := strconv.ParseFloat(ctx.FromTop, 64); err2 == nil {
 		percentile = fromTop
 	} else {

--- a/api/lists.go
+++ b/api/lists.go
@@ -130,10 +130,8 @@ func (c *ListsController) GetPercentile(ctx *app.GetPercentileListsContext) erro
 	if !ok {
 		return ctx.NotFound(goa.ErrNotFound("not_found", "list_id", ctx.ListID))
 	}
-	var percentile float64
-	if fromTop, err2 := strconv.ParseFloat(ctx.FromTop, 64); err2 == nil {
-		percentile = fromTop
-	} else {
+	percentile, err := strconv.ParseFloat(ctx.FromTop, 64)
+	if err != nil {
 		return ctx.BadRequest(goa.InvalidParamTypeError("from_top", ctx.FromTop, "number"))
 	}
 	if percentile < 0 {

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 	err = conf.Close()
 	exitOnFailure(err)
 	enableJWTCreation = true
-	go StartServices(logger, ctx, err)
+	go StartServices(logger, ctx)
 	<-listening
 
 	// Initialize clients

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -39,9 +39,6 @@ const (
 	// ContentTypeMsgpack specifies a messagepack encoding.
 	// Compact and fast.
 	contentMsgpack = "application/msgpack"
-
-	// ContentTypeJSON forces JSON as transport protocol.
-	contentJSON = "application/json"
 )
 
 var (
@@ -52,6 +49,7 @@ var (
 	tClientManage *client.Client
 )
 
+//nolint:staticcheck
 func TestMain(m *testing.M) {
 	lr := logrus.New()
 	lr.Formatter = &logrus.TextFormatter{DisableColors: true}
@@ -107,7 +105,7 @@ func initClient(ctx context.Context, dstClient **client.Client, scope string) {
 		"scopes": scope,                // token scope - not a standard claim
 	}
 	token.Claims = claims
-	signedToken, err := token.SignedString(privKey)
+	signedToken, _ := token.SignedString(privKey)
 
 	cl.JWTSigner = &goaclient.JWTSigner{
 		TokenSource: &goaclient.StaticTokenSource{

--- a/api/multilist.go
+++ b/api/multilist.go
@@ -472,7 +472,7 @@ func onEveryList(ctx context.Context, lists rankdb.ListIDs, limit int, fn func(l
 	var mu sync.Mutex
 	var results = app.RankdbResultlist{
 		Success: make(map[string]*app.RankdbOperationSuccess, len(lists)),
-		Errors:  make(map[string]string, 0),
+		Errors:  make(map[string]string),
 	}
 	var tokens = make(chan struct{}, limit)
 	for i := 0; i < limit; i++ {

--- a/api/multilist_test.go
+++ b/api/multilist_test.go
@@ -286,7 +286,7 @@ func TestMultilistController_Backup(t *testing.T) {
 	}
 	createList(t, t.Name(), elems)
 	createList(t, t.Name()+"-2", elems)
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, _ := ioutil.TempDir("", t.Name())
 	fileName := filepath.Join(dir, t.Name()+".bin")
 	payload := client.MultiListBackup{
 		Destination: &client.BackupDestination{

--- a/api/rankdb.go
+++ b/api/rankdb.go
@@ -232,7 +232,6 @@ func StartServer(ctx context.Context, confData io.Reader, lr *logrus.Logger) err
 		updateBucket = rankdb.NewBucket(config.MaxUpdates)
 	}
 	if config.CacheEntries > 0 {
-		err = nil
 		switch config.CacheType {
 		case "", "ARC":
 			cache, err = lru.NewARC(config.CacheEntries)

--- a/api/services.go
+++ b/api/services.go
@@ -30,6 +30,9 @@ var (
 )
 
 func StartServices(logger goa.LogAdapter, ctx context.Context, err error) {
+	if err != nil {
+		return
+	}
 	shutdown.PreShutdownFn(func() {
 		close(shutdownStarted)
 	})

--- a/api/services.go
+++ b/api/services.go
@@ -29,10 +29,7 @@ var (
 	listenAddr net.Addr
 )
 
-func StartServices(logger goa.LogAdapter, ctx context.Context, err error) {
-	if err != nil {
-		return
-	}
+func StartServices(logger goa.LogAdapter, ctx context.Context) {
 	shutdown.PreShutdownFn(func() {
 		close(shutdownStarted)
 	})

--- a/api/shutdown.go
+++ b/api/shutdown.go
@@ -18,7 +18,7 @@ import (
 var (
 	errShutdown     = goa.NewErrorClass("server_restarting", http.StatusServiceUnavailable)("Server restarting")
 	errCancelled    = goa.NewErrorClass("request_cancelled", 499)("Request Cancelled")
-	shutdownStarted = make(chan struct{}, 0)
+	shutdownStarted = make(chan struct{})
 )
 
 // ShutdownMiddleware rejects request once shutdown starts.
@@ -32,7 +32,6 @@ func ShutdownMiddleware(h goa.Handler) goa.Handler {
 		err := h(ctx, rw, req)
 		if err == context.Canceled || ctx.Err() == context.Canceled {
 			log.Info(ctx, "Context was cancelled")
-			err = nil
 			if shutdown.Started() {
 				return errShutdown
 			}

--- a/api/tool/rankdb-cli/main.go
+++ b/api/tool/rankdb-cli/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	// Execute!
 	if err := app.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
 		os.Exit(-1)
 	}
 }

--- a/backup/job.go
+++ b/backup/job.go
@@ -53,7 +53,6 @@ func (id ID) Cancel() {
 		return
 	}
 	job.cancel()
-	return
 }
 
 func (id ID) String() string {

--- a/backup/s3/s3.go
+++ b/backup/s3/s3.go
@@ -48,7 +48,7 @@ func (f *File) Save(ctx context.Context) (io.WriteCloser, error) {
 	go func() {
 		res, err := uploader.UploadWithContext(ctx, &input)
 		if err != nil {
-			reader.CloseWithError(err)
+			_ = reader.CloseWithError(err)
 			log.Error(ctx, "Unable to upload data", "error", err.Error())
 		}
 		f.Result <- res

--- a/backup/server/rankdb.go
+++ b/backup/server/rankdb.go
@@ -88,7 +88,7 @@ func (b *bodyWriter) Transfer(ctx context.Context) {
 	}
 	log.Info(ctx, "Destination server returned ok", "full_path", b.req.URL.String())
 	b.r.Close()
-	io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 }
 

--- a/blobstore/badgerstore/badger.go
+++ b/blobstore/badgerstore/badger.go
@@ -88,7 +88,7 @@ func (b *BadgerStore) flush() error {
 	txn := b.db.NewTransaction(true)
 	for k, v := range b.queue {
 		if err := txn.Set([]byte(k), v); err == badger.ErrTxnTooBig {
-			err = txn.Commit()
+			_ = txn.Commit()
 			txn = b.db.NewTransaction(true)
 			err = txn.Set([]byte(k), v)
 			if err != nil {

--- a/blobstore/bstest/bstest.go
+++ b/blobstore/bstest/bstest.go
@@ -1,3 +1,4 @@
+//nolint
 // Package bstest supplies helpers to test blobstores.
 package bstest
 
@@ -255,6 +256,7 @@ func (t Test) Colliding(ctx context.Context, tt *testing.T) {
 	}
 	gRNG := rand.New(rand.NewSource(1337))
 	set, key := randStringRng(20, gRNG.Int63()), randStringRng(20, gRNG.Int63())
+	//nolint:errcheck
 	test := func(i int) {
 		rng := rand.New(rand.NewSource(int64(i)))
 		var blobSize = int(rng.Int63()%MaxBlobSize) + 1

--- a/blobstore/lazysaver.go
+++ b/blobstore/lazysaver.go
@@ -179,7 +179,7 @@ func NewLazySaver(store Store, opts ...lazySaveOption) (*LazySaver, error) {
 		cacheIdx:        make(map[string]*list.Element),
 		itemAdded:       make(chan struct{}, 1),
 		savech:          make(chan *list.Element),
-		shutdownCh:      make(chan struct{}, 0),
+		shutdownCh:      make(chan struct{}),
 	}
 	for _, opt := range opts {
 		err := opt(&l.lazySaveOptions)
@@ -681,5 +681,6 @@ func putDataBufferChunk(p []byte) {
 	if size >= 1<<20 {
 		i = 10
 	}
+	//nolint - don't tell me what to make pointerlike
 	dataChunkPools[i].Put(p[:0])
 }

--- a/cmd/rankdb/main.go
+++ b/cmd/rankdb/main.go
@@ -54,7 +54,7 @@ func main() {
 	var dumpOnce sync.Once
 	shutdown.OnTimeout(func(stage shutdown.Stage, s string) {
 		dumpOnce.Do(func() {
-			pprof.Lookup("goroutine").WriteTo(lr.Out, 1)
+			_ = pprof.Lookup("goroutine").WriteTo(lr.Out, 1)
 		})
 	})
 

--- a/cmd/rankdb/main.go
+++ b/cmd/rankdb/main.go
@@ -74,7 +74,7 @@ func main() {
 			}
 		}()
 	}
-	api.StartServices(logger, ctx, err)
+	api.StartServices(logger, ctx)
 }
 
 // exitOnFailure prints a fatal error message and exits the process with status 1.

--- a/elements.go
+++ b/elements.go
@@ -314,7 +314,6 @@ func (l *Elements) MergeDeduplicate(ins Elements) {
 	// Re-sort.
 	sort.Slice(ins, ins.Sorter())
 	*l = ins
-	return
 }
 
 // MinMax returns the minimum and maximum values of the elements.
@@ -449,22 +448,6 @@ func (e Elements) FirstElementsWithScore(scores []uint64) Elements {
 		}
 	}
 	return res
-}
-
-// minMaxUnsorted provides the smallest and biggest score
-// on unsorted elements.
-func (l Elements) minMaxUnsorted() (min, max uint64) {
-	min = math.MaxUint64
-	max = 0
-	for _, v := range l {
-		if v.Score > max {
-			max = v.Score
-		}
-		if v.Score < min {
-			min = v.Score
-		}
-	}
-	return min, max
 }
 
 // ElementIDs returns element ids as ranked elements,

--- a/elements_test.go
+++ b/elements_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/Vivino/rankdb"
-	"github.com/stretchr/testify/assert"
 )
 
 type counter uint64
@@ -34,34 +33,20 @@ func TestElements_Add(t *testing.T) {
 	lst := rankdb.Elements{}
 	cnt := counter(1000)
 	now := time.Now()
-	_, err := lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(-time.Hour))})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(time.Hour))})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	assert.NoError(t, err)
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(-time.Hour))})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(time.Hour))})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
 	if len(lst) < 5 {
 		t.Fatal("Want elements in list, found ", len(lst))
 	}
@@ -85,7 +70,7 @@ func TestElements_Delete(t *testing.T) {
 
 func testElements_DeleteAt(t *testing.T, n int, orig rankdb.Elements) {
 	testOn := orig.Clone(true)
-	assert.NoError(t, testOn.Delete(orig[n].ID))
+	testOn.Delete(orig[n].ID)
 	if len(orig)-1 != len(testOn) {
 		t.Fatal("did not remove element")
 	}
@@ -303,20 +288,13 @@ func TestIndexElements_SegmentSorter(t *testing.T) {
 	lst := rankdb.Elements{}
 	cnt := counter(1000)
 	now := timeUnix(time.Now())
-	_, err := lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
-	assert.NoError(t, err)
-	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 2, Updated: now})
-	assert.NoError(t, err)
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
+	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
+	lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 2, Updated: now})
 	idx := rankdb.IndexElements{Elements: lst}
 	sort.Slice(idx.Elements, idx.SegmentSorter())
 	wantE := []struct {
@@ -523,6 +501,27 @@ func randElements(n int, seed ...int64) rankdb.Elements {
 			Updated:    timeUnix(time.Now().Add(-time.Millisecond * time.Duration(rng.Int63n(int64(time.Hour)*24*365)))),
 			ID:         rankdb.ElementID(rng.Uint64()),
 			Payload:    []byte(`{"value":"` + rankdb.RandString(5) + `", "type": "user-list"}`),
+		}
+	}
+	return res
+}
+
+func randSortedElements(n int, seed ...int64) rankdb.Elements {
+	if n == 0 {
+		return rankdb.Elements{}
+	}
+	rng := rand.New(rand.NewSource(0x1337beefc0cac01a))
+	if len(seed) > 0 {
+		rng = rand.New(rand.NewSource(seed[0]))
+	}
+	res := make(rankdb.Elements, n)
+	for i := range res {
+		res[i] = rankdb.Element{
+			Score:      uint64(n - i),
+			TieBreaker: rng.Uint32(),
+			Updated:    timeUnix(time.Now().Add(-time.Millisecond * time.Duration(rng.Int63n(int64(time.Hour)*24*365)))),
+			ID:         rankdb.ElementID(rng.Uint64()),
+			Payload:    nil,
 		}
 	}
 	return res

--- a/elements_test.go
+++ b/elements_test.go
@@ -1,3 +1,4 @@
+//nolint:errcheck
 package rankdb_test
 
 // Copyright 2019 Vivino. All rights reserved
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Vivino/rankdb"
+	"github.com/stretchr/testify/assert"
 )
 
 type counter uint64
@@ -32,20 +34,34 @@ func TestElements_Add(t *testing.T) {
 	lst := rankdb.Elements{}
 	cnt := counter(1000)
 	now := time.Now()
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(-time.Hour))})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(time.Hour))})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
-	lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	_, err := lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(-time.Hour))})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now.Add(time.Hour))})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 100, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 1, Updated: timeUnix(now)})
+	assert.NoError(t, err)
 	if len(lst) < 5 {
 		t.Fatal("Want elements in list, found ", len(lst))
 	}
@@ -69,7 +85,7 @@ func TestElements_Delete(t *testing.T) {
 
 func testElements_DeleteAt(t *testing.T, n int, orig rankdb.Elements) {
 	testOn := orig.Clone(true)
-	testOn.Delete(orig[n].ID)
+	assert.NoError(t, testOn.Delete(orig[n].ID))
 	if len(orig)-1 != len(testOn) {
 		t.Fatal("did not remove element")
 	}
@@ -287,13 +303,20 @@ func TestIndexElements_SegmentSorter(t *testing.T) {
 	lst := rankdb.Elements{}
 	cnt := counter(1000)
 	now := timeUnix(time.Now())
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
-	lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
-	lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 2, Updated: now})
+	_, err := lst.Add(rankdb.Element{ID: cnt.next(), Score: 1000})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 100000})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 10})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 100})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next(), Score: 500, TieBreaker: 1})
+	assert.NoError(t, err)
+	_, err = lst.Add(rankdb.Element{ID: cnt.next() - 200, Score: 500, TieBreaker: 2, Updated: now})
+	assert.NoError(t, err)
 	idx := rankdb.IndexElements{Elements: lst}
 	sort.Slice(idx.Elements, idx.SegmentSorter())
 	wantE := []struct {
@@ -500,27 +523,6 @@ func randElements(n int, seed ...int64) rankdb.Elements {
 			Updated:    timeUnix(time.Now().Add(-time.Millisecond * time.Duration(rng.Int63n(int64(time.Hour)*24*365)))),
 			ID:         rankdb.ElementID(rng.Uint64()),
 			Payload:    []byte(`{"value":"` + rankdb.RandString(5) + `", "type": "user-list"}`),
-		}
-	}
-	return res
-}
-
-func randSortedElements(n int, seed ...int64) rankdb.Elements {
-	if n == 0 {
-		return rankdb.Elements{}
-	}
-	rng := rand.New(rand.NewSource(0x1337beefc0cac01a))
-	if len(seed) > 0 {
-		rng = rand.New(rand.NewSource(seed[0]))
-	}
-	res := make(rankdb.Elements, n)
-	for i := range res {
-		res[i] = rankdb.Element{
-			Score:      uint64(n - i),
-			TieBreaker: rng.Uint32(),
-			Updated:    timeUnix(time.Now().Add(-time.Millisecond * time.Duration(rng.Int63n(int64(time.Hour)*24*365)))),
-			ID:         rankdb.ElementID(rng.Uint64()),
-			Payload:    nil,
 		}
 	}
 	return res

--- a/list-id.go
+++ b/list-id.go
@@ -48,5 +48,4 @@ func (ids ListIDs) Sort() {
 	sort.Slice(ids, func(i, j int) bool {
 		return ids[i] < ids[j]
 	})
-	return
 }

--- a/list.go
+++ b/list.go
@@ -1022,7 +1022,9 @@ func (l *List) Stats(ctx context.Context, bs blobstore.Store, elements bool) (*L
 	index := segs.index
 
 	res.Elements = scores.Elements()
+	//nolint - why's it okay to use scores before checking if it's nil again?
 	res.Segments = len(scores.Segments)
+	//nolint - why's it okay to use scores before checking if it's nil again?
 	if scores != nil {
 		res.CacheHits = l.scores.cacheHits + l.index.cacheHits
 		res.CacheMisses = l.scores.cacheMisses + l.index.cacheMisses

--- a/list.go
+++ b/list.go
@@ -783,8 +783,8 @@ func (l *List) reindex(ctx context.Context, bs blobstore.Store, segs *segments) 
 // VerifyUnlocked validates that all elements of the list can be locked.
 // This is only really usable for tests, where list context is controlled.
 func (l *List) VerifyUnlocked(ctx context.Context, timeout time.Duration) error {
-	var fail = make(chan struct{}, 0)
-	var ok = make(chan struct{}, 0)
+	var fail = make(chan struct{})
+	var ok = make(chan struct{})
 	var wg = &sync.WaitGroup{}
 
 	go func() {
@@ -806,7 +806,7 @@ func (l *List) VerifyUnlocked(ctx context.Context, timeout time.Duration) error 
 		return errors.New("timeout acquiring locks")
 	case <-ok:
 	}
-	ok = make(chan struct{}, 0)
+	ok = make(chan struct{})
 
 	// We need read lock.
 	l.RLock()
@@ -837,7 +837,7 @@ func (l *List) VerifyUnlocked(ctx context.Context, timeout time.Duration) error 
 
 	select {
 	case <-fail:
-		pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
 		time.Sleep(time.Millisecond * 100)
 		return errors.New("timeout acquiring locks")
 	case <-ok:
@@ -848,7 +848,7 @@ func (l *List) VerifyUnlocked(ctx context.Context, timeout time.Duration) error 
 
 func testLock(log log.Adapter, fail chan struct{}, locker sync.Locker, wg *sync.WaitGroup) {
 	wg.Add(1)
-	var ok = make(chan struct{}, 0)
+	var ok = make(chan struct{})
 	go func() {
 		locker.Lock()
 		close(ok)
@@ -1057,7 +1057,7 @@ func (l *List) Stats(ctx context.Context, bs blobstore.Store, elements bool) (*L
 func (l *List) ReleaseSegments(ctx context.Context) {
 	ctx = log.WithFn(ctx)
 	var gotLoading, gotSegments, cancelled bool
-	var done = make(chan struct{}, 0)
+	var done = make(chan struct{})
 	var mu sync.Mutex
 	l.RLock()
 	listID := l.ID

--- a/list_test.go
+++ b/list_test.go
@@ -240,6 +240,9 @@ func TestNewListClone(t *testing.T) {
 		rankdb.WithListOption.Clone(l0),
 		rankdb.WithListOption.Cache(nil),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Delete all of original
 	err = l0.DeleteAll(ctx, store)

--- a/list_test.go
+++ b/list_test.go
@@ -1,3 +1,4 @@
+//nolint
 package rankdb_test
 
 // Copyright 2019 Vivino. All rights reserved

--- a/lists_test.go
+++ b/lists_test.go
@@ -1,3 +1,4 @@
+//nolint
 package rankdb_test
 
 // Copyright 2019 Vivino. All rights reserved

--- a/msgppool.go
+++ b/msgppool.go
@@ -35,9 +35,7 @@ var writerMsgpPool = sync.Pool{
 	},
 }
 
-//nolint - versionExt is unused, but someone apparently thought it should be here anyway?
 const (
-	versionExt   = 0   // Reserved for future extensions.
 	versionError = 255 // Error
 )
 

--- a/msgppool.go
+++ b/msgppool.go
@@ -35,6 +35,7 @@ var writerMsgpPool = sync.Pool{
 	},
 }
 
+//nolint - versionExt is unused, but someone apparently thought it should be here anyway?
 const (
 	versionExt   = 0   // Reserved for future extensions.
 	versionError = 255 // Error

--- a/ranksdb_test.go
+++ b/ranksdb_test.go
@@ -16,7 +16,7 @@ func TestMain(m *testing.M) {
 	go func() {
 		<-time.After(200 * time.Second)
 		fmt.Println("200 second timeout... Goroutines:")
-		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 		os.Exit(1)
 	}()
 	os.Exit(m.Run())

--- a/segment.go
+++ b/segment.go
@@ -192,7 +192,7 @@ func (s *Segment) loadElements(ctx context.Context, store blobstore.WithSet, rea
 		}
 		return forReader, err
 	}
-	s.loader.Loading = make(chan struct{}, 0)
+	s.loader.Loading = make(chan struct{})
 	s.loader.LoadingMu.Unlock()
 	defer func() {
 		// Signal others we are loaded.

--- a/sortfloat/float_test.go
+++ b/sortfloat/float_test.go
@@ -25,7 +25,7 @@ func TestSortableFloat64(t *testing.T) {
 		tosort = append(tosort, forward)
 	}
 	sort.SliceStable(tosort, func(i, j int) bool { return tosort[i] < tosort[j] })
-	sort.Sort(sort.Float64Slice(values))
+	sort.Float64s(values)
 
 	for i, v := range values {
 		got := ReverseFloat64(tosort[i])

--- a/tools.go
+++ b/tools.go
@@ -81,14 +81,9 @@ finish:
 		select {
 		case <-ctx.Done():
 			// Flush errors and return.
-			for {
-				select {
-				case _, ok := <-errch:
-					if !ok {
-						return ctx.Err()
-					}
-				}
+			for range errch {
 			}
+			return ctx.Err()
 		case err, ok := <-errch:
 			if !ok {
 				break finish


### PR DESCRIPTION
Fixes complaints from golang-ci-lint, by ignoring error returns in places they don't matter, nolint'ing test-code because that's not worth it IMO, and fixing the rest of the complaints.