### PR TITLE
bump to go1.26 and use mod file as version authority

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.23.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -21,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -40,13 +39,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23.x
-
-      - name: Checkout code
-        uses: actions/checkout@v7
+          go-version-file: go.mod
 
       - name: goreleaser deprecation
         run: curl -sfL https://git.io/goreleaser | VERSION=v1.2.5 sh -s -- check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23.x"
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Vivino/rankdb
 
-go 1.23
+go 1.26
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
Bumping the go version to 1.26.
Workflows now use the go.mod go version declaration as authority.